### PR TITLE
Improved the API for LoopVariable to help improve handling exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1352,7 +1352,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>1.4.200</version>
+			<version>2.1.214</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/src/main/java/nz/co/gregs/dbvolution/databases/DBStatement.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/DBStatement.java
@@ -124,21 +124,17 @@ public class DBStatement implements AutoCloseable {
 			} else if (details.isIgnoreExceptions()) {
 				// do nothing
 			} else {
-				LOG.info("REPEATED EXCEPTIONS FROM: " + sql, exp);
-//				System.out.println("REPEATED EXCEPTIONS FROM: " + sql);
-				exp.printStackTrace();
-//				System.out.println("SECONDLY");
-				ex.printStackTrace();
+//				LOG.info("REPEATED EXCEPTIONS FROM: " + sql, exp);
 			}
 			Exception ex1 = exp;
 			while (!ex1.getMessage().equals(ex.getMessage())) {
-				DBDatabase.ResponseToException response = handleResponseFromFixingException(exp, intent, details);
-				if (response.equals(DBDatabase.ResponseToException.SKIPQUERY)) {
-					return null;
+					DBDatabase.ResponseToException response = handleResponseFromFixingException(exp, intent, details);
+					if (response.equals(DBDatabase.ResponseToException.SKIPQUERY)) {
+						return null;
+					}
 				}
-			}
 			throw new SQLException(ex);
-		}
+			}
 		try {
 			executeQuery = getInternalStatement().executeQuery(sql);
 			return executeQuery;

--- a/src/main/java/nz/co/gregs/dbvolution/internal/database/DatabaseList.java
+++ b/src/main/java/nz/co/gregs/dbvolution/internal/database/DatabaseList.java
@@ -206,7 +206,7 @@ public class DatabaseList implements Serializable {
 		return getDatabases(statuses).length;
 	}
 
-	public synchronized void clear() {
+	public void clear() {
 		statusMap.clear();
 		databaseMap.clear();
 	}

--- a/src/main/java/nz/co/gregs/dbvolution/internal/query/QueryCanceller.java
+++ b/src/main/java/nz/co/gregs/dbvolution/internal/query/QueryCanceller.java
@@ -77,7 +77,7 @@ public class QueryCanceller implements Runnable {
 			statement.cancel();
 			setQueryWasCancelled(true);
 		} catch (SQLException ex) {
-			Logger.getLogger(QueryDetails.class.getName()).log(Level.SEVERE, null, ex);
+			Logger.getLogger(QueryDetails.class.getName()).log(Level.SEVERE, "QueryCanceller caught an exception", ex);
 		}
 	}
 	protected static final Logger LOGGER = Logger.getLogger(QueryCanceller.class.getName());

--- a/src/main/java/nz/co/gregs/dbvolution/internal/query/RecursiveQueryDetails.java
+++ b/src/main/java/nz/co/gregs/dbvolution/internal/query/RecursiveQueryDetails.java
@@ -47,6 +47,7 @@ import nz.co.gregs.dbvolution.columns.NumberColumn;
 import nz.co.gregs.dbvolution.columns.StringColumn;
 import nz.co.gregs.dbvolution.databases.DBDatabase;
 import nz.co.gregs.dbvolution.databases.DBStatement;
+import nz.co.gregs.dbvolution.databases.QueryIntention;
 import nz.co.gregs.dbvolution.databases.definitions.DBDefinition;
 import nz.co.gregs.dbvolution.datatypes.DBDate;
 import nz.co.gregs.dbvolution.datatypes.DBInteger;
@@ -199,7 +200,9 @@ public class RecursiveQueryDetails<T extends DBRow> extends QueryDetails {
 			String descendingQuery = getRecursiveSQL(database, recursiveDetails, recursiveDetails.getKeyToFollow(), direction);
 			query.setTimeoutInMilliseconds(recursiveDetails.getTimeoutInMilliseconds());
 			final QueryDetails queryDetails = query.getQueryDetails();
-			try (ResultSet resultSet = queryDetails.getResultSetForSQL(dbStatement, descendingQuery)) {
+			final StatementDetails statementDetails = new StatementDetails(getLabel(), QueryIntention.RECURSIVE_QUERY, descendingQuery, dbStatement);
+			statementDetails.setIgnoreExceptions(this.isQuietExceptions());
+			try (ResultSet resultSet = queryDetails.getResultSetForSQL(dbStatement, statementDetails, descendingQuery)) {
 				if (resultSet != null) {
 					while (resultSet.next()) {
 						DBQueryRow queryRow = new DBQueryRow(queryDetails);

--- a/src/test/java/nz/co/gregs/dbvolution/MultiplePrimaryKeyTests.java
+++ b/src/test/java/nz/co/gregs/dbvolution/MultiplePrimaryKeyTests.java
@@ -21,10 +21,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import nz.co.gregs.dbvolution.annotations.DBAutoIncrement;
-import nz.co.gregs.dbvolution.annotations.DBColumn;
-import nz.co.gregs.dbvolution.annotations.DBForeignKey;
-import nz.co.gregs.dbvolution.annotations.DBPrimaryKey;
+import nz.co.gregs.dbvolution.annotations.*;
 import nz.co.gregs.dbvolution.datatypes.DBDate;
 import nz.co.gregs.dbvolution.datatypes.DBInteger;
 import nz.co.gregs.dbvolution.datatypes.DBPasswordHash;
@@ -212,6 +209,7 @@ public class MultiplePrimaryKeyTests extends AbstractTest {
 
 	}
 
+	@DBTableName("USER_TABLE_FOR_TESTING")
 	public static class User extends DBRow {
 
 	private static final long serialVersionUID = 1L;

--- a/src/test/java/nz/co/gregs/dbvolution/PrimaryKeylessTableTest.java
+++ b/src/test/java/nz/co/gregs/dbvolution/PrimaryKeylessTableTest.java
@@ -45,7 +45,7 @@ public class PrimaryKeylessTableTest extends AbstractTest {
 		dbQuery.setBlankQueryAllowed(true);
 		String sqlForQuery = dbQuery.getSQLForQuery();
 		assertThat(
-				testableSQL(sqlForQuery),
+				testableSQLWithoutColumnAliases(sqlForQuery),
 				anyOf(
 						is(testableSQLWithoutColumnAliases("select __78874071.name db_241667647, __78874071.uid_carcompany db112832814, _1617907935.fk_car_company db_238514883, _1617907935.fk_company_logo db_1915875486 from car_company as __78874071 inner join lt_carco_logo as _1617907935 on( _1617907935.fk_car_company = __78874071.uid_carcompany ) ;")),
 						is(testableSQLWithoutColumnAliases("select __78874071.name db_241667647, __78874071.uid_carcompany db112832814, _1617907935.fk_car_company db_238514883, _1617907935.fk_company_logo db_1915875486 from [car_company] as __78874071 inner join [lt_carco_logo] as _1617907935 on( _1617907935.fk_car_company = __78874071.uid_carcompany )")),
@@ -71,7 +71,7 @@ public class PrimaryKeylessTableTest extends AbstractTest {
 		if (!(database instanceof DBDatabaseCluster)) {
 			String sqlForQuery = dbQuery.getSQLForQuery();
 			assertThat(
-					testableSQL(sqlForQuery),
+					testableSQLWithoutColumnAliases(sqlForQuery),
 					anyOf(
 							is(testableSQLWithoutColumnAliases("select __78874071.name db_241667647, __78874071.uid_carcompany db112832814, _1617907935.fk_car_company db_238514883, _1617907935.fk_company_logo db_1915875486, _1159239592.logo_id db_1579317226, _1159239592.car_company_fk db1430605643, _1159239592.image_file db1622411417, _1159239592.image_name db1622642088 from car_company as __78874071 inner join lt_carco_logo as _1617907935 on( _1617907935.fk_car_company = __78874071.uid_carcompany ) inner join companylogo as _1159239592 on( _1159239592.car_company_fk = __78874071.uid_carcompany and _1617907935.fk_company_logo = _1159239592.logo_id ) ;")),
 							is(testableSQLWithoutColumnAliases("select __78874071.name db_241667647, __78874071.uid_carcompany db112832814, _1159239592.logo_id db_1579317226, _1159239592.car_company_fk db1430605643, _1159239592.image_file db1622411417, _1159239592.image_name db1622642088, _1617907935.fk_car_company db_238514883, _1617907935.fk_company_logo db_1915875486 from car_company as __78874071 inner join companylogo as _1159239592 on( _1159239592.car_company_fk = __78874071.uid_carcompany ) inner join lt_carco_logo as _1617907935 on( _1617907935.fk_car_company = __78874071.uid_carcompany and _1617907935.fk_company_logo = _1159239592.logo_id ) ;")),

--- a/src/test/java/nz/co/gregs/dbvolution/datatypes/DBBooleanArrayTest.java
+++ b/src/test/java/nz/co/gregs/dbvolution/datatypes/DBBooleanArrayTest.java
@@ -117,7 +117,8 @@ public class DBBooleanArrayTest extends AbstractTest {
 				anyOf(
 						is("'011'"), //MS SQLServer
 						is("b'110'"), //MySQL
-						is("(FALSE,TRUE,TRUE)"), //H2
+						is("(FALSE,TRUE,TRUE)"), //H2v1
+						is("ARRAY[FALSE, TRUE, TRUE]"), //H2v2
 						is("'{0,1,1}'") // Postgres
 				)
 		);

--- a/src/test/java/nz/co/gregs/dbvolution/datatypes/DBEnumTest.java
+++ b/src/test/java/nz/co/gregs/dbvolution/datatypes/DBEnumTest.java
@@ -71,7 +71,7 @@ public class DBEnumTest extends AbstractTest {
 				IntEnum.SHIPPING_MANIFEST_RECORD);
 
 		String sqlFragment = database.getDBQuery(rowExemplar).getSQLForQuery();
-		assertThat(sqlFragment.toLowerCase(), containsString("c_5 in ( 2, 1)"));
+		assertThat(sqlFragment.toLowerCase(), anyOf(containsString("c_5 in ( 2, 1)"),containsString("\"c_5\" in ( 2, 1)")));
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class DBEnumTest extends AbstractTest {
 				IntEnum.SHIPPING_MANIFEST_RECORD.getCode());
 
 		String sqlFragment = database.getDBQuery(rowExemplar).getSQLForQuery();
-		assertThat(sqlFragment.toLowerCase(), containsString("c_5 in ( 2, 1)"));
+		assertThat(sqlFragment.toLowerCase(), anyOf(containsString("c_5 in ( 2, 1)"),containsString("\"c_5\" in ( 2, 1)")));
 	}
 
 	@Test

--- a/src/test/java/nz/co/gregs/dbvolution/generic/AbstractTest.java
+++ b/src/test/java/nz/co/gregs/dbvolution/generic/AbstractTest.java
@@ -267,6 +267,9 @@ public abstract class AbstractTest {
 						.replaceAll("\\b_+", "")
 						.replaceAll(" +[aA][sS] +", " ")
 						.replaceAll(" *; *$", "");
+			}else if (database instanceof H2DB)  {
+				return trimStr
+						.replaceAll("\"", "");
 			} else if (database instanceof PostgresDB) {
 				return trimStr.replaceAll("::[a-zA-Z]*", "");
 			} else if ((database instanceof NuoDB)) {
@@ -285,7 +288,7 @@ public abstract class AbstractTest {
 		if (str != null) {
 			String trimStr = str
 					.trim()
-					.replaceAll(" DB[_0-9]+", "")
+					.replaceAll(" [dD][bB][_0-9]+", "")
 					.replaceAll("[ \\r\\n]+", " ")
 					.replaceAll(", ", ",")
 					.toLowerCase();
@@ -297,6 +300,9 @@ public abstract class AbstractTest {
 						.replaceAll("\\b_+", "")
 						.replaceAll(" *; *$", "")
 						.replaceAll(" as ", " ");
+			} else if (database instanceof H2DB) {
+				return trimStr
+						.replaceAll("\"", "");
 			} else if ((database instanceof NuoDB)) {
 				return trimStr.replaceAll("\\(\\(([^)]*)\\)=true\\)", "$1");
 			} else if ((database instanceof MSSQLServerDB)) {

--- a/src/test/java/nz/co/gregs/dbvolution/internal/querygraph/QueryGraphEdgeLabelTransformerTest.java
+++ b/src/test/java/nz/co/gregs/dbvolution/internal/querygraph/QueryGraphEdgeLabelTransformerTest.java
@@ -65,9 +65,13 @@ public class QueryGraphEdgeLabelTransformerTest extends AbstractTest {
 		DBExpression v = marque.column(marque.carCompany).is(2);
 		DBQuery dbQuery = database.getDBQuery(marque);
 		QueryGraphEdgeLabelTransformer instance = new QueryGraphEdgeLabelTransformer(dbQuery);
-		String expResult = "fk_carcompany = 2";
 		String result = instance.transform(v);
-		assertThat(result.toLowerCase(), containsString(expResult));
+		assertThat(result.toLowerCase(), 
+				anyOf(
+						containsString("fk_carcompany = 2"), 
+						containsString("\"fk_carcompany\" = 2")
+				)
+		);
 	}
 
 }


### PR DESCRIPTION
Moved H2 from 1.4.200 to v2.1.214 which is a latest (Please note that v1 and v2 file formats are not compatible and that is H2 decision, not mine) Removed confusing exception reporting from DBStatement and pushed it higher up so that we don't get exceptions reported when there are alternative queries still available. H2 oracle compatibility, in particular, uses 4 options for grouping and has been complaining about the first option being wrong despite 3 other options still being available. Corrected issue with H2 date format having too many "S"es and moving milliseconds into the nanoseconds range Added quoting to H2 column names to avoid problems with reserved words Changed the H2 syntax for declaring and using boolean arrays Removed the synchronized from DatabaseList.clear() as it can cause deadlocks Improved exception message within QueryCanceller