### PR TITLE
Add support for generating classes from schema tables

### DIFF
--- a/src/main/java/nz/co/gregs/dbvolution/DBMigration.java
+++ b/src/main/java/nz/co/gregs/dbvolution/DBMigration.java
@@ -82,7 +82,7 @@ public class DBMigration<M extends DBRow> extends RowDefinition implements Seria
 		return new DBMigration<MAPPER>(database, migrationMapper);
 	}
 
-	private DBMigration<M> addTablesAndExpressions(DBQuery query) {
+	public DBMigration<M> addTablesAndExpressions(DBQuery query) {
 		Field[] fields = mapper.getClass().getFields();
 		if (fields.length == 0) {
 			throw new UnableToAccessDBMigrationFieldException(this, null);
@@ -469,7 +469,7 @@ public class DBMigration<M extends DBRow> extends RowDefinition implements Seria
 	 *
 	 * @return the sortColumns
 	 */
-	protected SortProvider[] getSortColumns() {
+	public SortProvider[] getSortColumns() {
 		return sortColumns.toArray(new SortProvider[]{});
 	}
 
@@ -561,6 +561,25 @@ public class DBMigration<M extends DBRow> extends RowDefinition implements Seria
 
 	QueryDetails getQueryDetails() {
 		return this.getDBQuery().getQueryDetails();
+	}
+
+	public boolean getCartesianJoinsAllowed() {
+		return cartesian;
+	}
+
+	public boolean getBlankQueryAllowed() {
+		return blank;
+	}
+
+	public M getMapper() {
+		return mapper;
+	}
+	
+	public List<DBRow> getOptionalTables(){
+		if(optionalTables.isEmpty()){
+			return new ArrayList<DBRow>();
+		}
+		return Arrays.asList((DBRow[]) optionalTables.toArray());
 	}
 
 }

--- a/src/main/java/nz/co/gregs/dbvolution/DBQuery.java
+++ b/src/main/java/nz/co/gregs/dbvolution/DBQuery.java
@@ -1824,7 +1824,7 @@ public class DBQuery implements Serializable {
 	 *
 	 * @return this DBQuery instance
 	 */
-	protected DBQuery addGroupByColumn(Object identifyingObject, DBExpression expressionToAdd) {
+	public DBQuery addGroupByColumn(Object identifyingObject, DBExpression expressionToAdd) {
 		details.addDBReportGroupByColumn(identifyingObject, expressionToAdd);
 		return this;
 	}

--- a/src/main/java/nz/co/gregs/dbvolution/DBRow.java
+++ b/src/main/java/nz/co/gregs/dbvolution/DBRow.java
@@ -1093,7 +1093,7 @@ abstract public class DBRow extends RowDefinition implements Serializable {
 	 * Probably not useful in general use.
 	 *
 	 */
-	protected final void removeAllFieldsFromResults() {
+	public final void removeAllFieldsFromResults() {
 		setReturnFields(new Object[]{});
 	}
 

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractInformixSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractInformixSettingsBuilder.java
@@ -52,6 +52,7 @@ public abstract class AbstractInformixSettingsBuilder<SELF extends AbstractInfor
 		ExtrasCapableSettingsBuilder<SELF, DATABASE> {
 
 	protected static final HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public Map<String, String> getDefaultConfigurationExtras() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractJavaDBSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractJavaDBSettingsBuilder.java
@@ -56,6 +56,7 @@ public abstract class AbstractJavaDBSettingsBuilder<SELF extends AbstractJavaDBS
 			put("create", "true");
 		}
 	};
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public String getDefaultDriverName() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractMSSQLServerSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractMSSQLServerSettingsBuilder.java
@@ -52,6 +52,7 @@ public abstract class AbstractMSSQLServerSettingsBuilder<SELF extends AbstractMS
 		ExtrasCapableSettingsBuilder<SELF, DATABASE> {
 
 	protected static final HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public Map<String, String> getDefaultConfigurationExtras() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractMySQLSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractMySQLSettingsBuilder.java
@@ -66,6 +66,7 @@ public abstract class AbstractMySQLSettingsBuilder<SELF extends AbstractMySQLSet
 			put("useSSL", "false");
 		}
 	};
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public String getDefaultDriverName() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractOracleSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractOracleSettingsBuilder.java
@@ -53,6 +53,7 @@ public abstract class AbstractOracleSettingsBuilder<SELF extends AbstractOracleS
 		RemoteCapableSettingsBuilder<SELF, DATABASE> {
 
 	private final static HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public String getDefaultDriverName() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractPostgresSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractPostgresSettingsBuilder.java
@@ -55,6 +55,7 @@ public abstract class AbstractPostgresSettingsBuilder<SELF extends AbstractPostg
 		ExtrasCapableSettingsBuilder<SELF, DATABASE> {
 
 	protected static final HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public Map<String, String> getDefaultConfigurationExtras() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractSettingsBuilder.java
@@ -30,6 +30,7 @@
  */
 package nz.co.gregs.dbvolution.databases.settingsbuilders;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -44,7 +45,9 @@ import nz.co.gregs.separatedstring.SeparatedStringBuilder;
  * @param <SELF> the class of the object returned by most methods, this should be the Class of "this"
  * @param <DATABASE> the class returned by {@link SettingsBuilder#getDBDatabase}
  */
-public abstract class AbstractSettingsBuilder<SELF extends AbstractSettingsBuilder<SELF, DATABASE>, DATABASE extends DBDatabase> implements SettingsBuilder<SELF, DATABASE> {
+public abstract class AbstractSettingsBuilder<SELF extends AbstractSettingsBuilder<SELF, DATABASE>, DATABASE extends DBDatabase> implements SettingsBuilder<SELF, DATABASE>, Serializable {
+
+	private static final long serialVersionUID = 1L;
 
 	private DatabaseConnectionSettings storedSettingsInAbstractURLInterpreter;
 

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractVendorSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/AbstractVendorSettingsBuilder.java
@@ -46,6 +46,8 @@ public abstract class AbstractVendorSettingsBuilder<SELF extends AbstractVendorS
 		extends AbstractSettingsBuilder<SELF, DATABASE> 
 		implements VendorSettingsBuilder<SELF, DATABASE> {
 
+	private static final long serialVersionUID = 1L;
+
 	private String driverName = getDefaultDriverName();
 	private DBDefinition definition = getDefaultDefinition();
 

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/DBDatabaseClusterSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/DBDatabaseClusterSettingsBuilder.java
@@ -47,6 +47,7 @@ public class DBDatabaseClusterSettingsBuilder extends AbstractSettingsBuilder<DB
 {
 
 	private final static HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 	private boolean useAutoRebuild = false;
 	private boolean useAutoReconnect = false;
 	private boolean useAutoStart = false;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2FileSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2FileSettingsBuilder.java
@@ -37,6 +37,8 @@ public class H2FileSettingsBuilder extends AbstractH2SettingsBuilder<H2FileSetti
 		implements FileBasedSettingsBuilder<H2FileSettingsBuilder, H2FileDB>,
 		NamedDatabaseCapableSettingsBuilder<H2FileSettingsBuilder, H2FileDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<H2FileDB> generatesURLForDatabase() {
 		return H2FileDB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2MemorySettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2MemorySettingsBuilder.java
@@ -42,6 +42,8 @@ public class H2MemorySettingsBuilder
 		implements
 		UniqueDatabaseCapableSettingsBuilder<H2MemorySettingsBuilder, H2MemoryDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public String getDefaultDriverName() {
 		return H2MemoryDB.DRIVER_NAME;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2SettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2SettingsBuilder.java
@@ -43,6 +43,8 @@ public class H2SettingsBuilder extends AbstractH2SettingsBuilder<H2SettingsBuild
 		ProtocolCapableSettingsBuilder<H2SettingsBuilder, H2DB>,
 		NamedDatabaseCapableSettingsBuilder<H2SettingsBuilder, H2DB>{
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<H2DB> generatesURLForDatabase() {
 		return H2DB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2SharedSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2SharedSettingsBuilder.java
@@ -40,6 +40,8 @@ public class H2SharedSettingsBuilder extends AbstractH2SettingsBuilder<H2SharedS
 		ProtocolCapableSettingsBuilder<H2SharedSettingsBuilder, H2SharedDB>,
 		NamedDatabaseCapableSettingsBuilder<H2SharedSettingsBuilder, H2SharedDB>{
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public String encodeHost(DatabaseConnectionSettings settings) {
 		String hostname = StringCheck.check(settings.getHost(), "localhost");

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/Informix11SettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/Informix11SettingsBuilder.java
@@ -37,6 +37,8 @@ import nz.co.gregs.dbvolution.databases.definitions.Informix11DBDefinition;
 public class Informix11SettingsBuilder 
 		extends AbstractInformixSettingsBuilder<Informix11SettingsBuilder, Informix11DB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<Informix11DB> generatesURLForDatabase() {
 		return Informix11DB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/InformixSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/InformixSettingsBuilder.java
@@ -38,6 +38,8 @@ import nz.co.gregs.dbvolution.databases.InformixDB;
  */
 public class InformixSettingsBuilder extends AbstractInformixSettingsBuilder<InformixSettingsBuilder, InformixDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<InformixDB> generatesURLForDatabase() {
 		return InformixDB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/JavaDBMemorySettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/JavaDBMemorySettingsBuilder.java
@@ -39,6 +39,8 @@ public class JavaDBMemorySettingsBuilder
 		extends AbstractJavaDBSettingsBuilder<JavaDBMemorySettingsBuilder, JavaDBMemoryDB>
 		implements UniqueDatabaseCapableSettingsBuilder<JavaDBMemorySettingsBuilder, JavaDBMemoryDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public DatabaseConnectionSettings setDefaultsInternal(DatabaseConnectionSettings settings) {
 		super.setDefaultsInternal(settings);

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/JavaDBSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/JavaDBSettingsBuilder.java
@@ -39,6 +39,8 @@ import nz.co.gregs.dbvolution.databases.JavaDB;
 public class JavaDBSettingsBuilder extends AbstractJavaDBSettingsBuilder<JavaDBSettingsBuilder, JavaDB>
 		implements ProtocolCapableSettingsBuilder<JavaDBSettingsBuilder, JavaDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<JavaDB> generatesURLForDatabase() {
 		return JavaDB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MSSQLServer2012SettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MSSQLServer2012SettingsBuilder.java
@@ -41,6 +41,8 @@ import nz.co.gregs.dbvolution.databases.definitions.MSSQLServer2012DBDefinition;
 public class MSSQLServer2012SettingsBuilder extends AbstractMSSQLServerSettingsBuilder<MSSQLServer2012SettingsBuilder, MSSQLServer2012DB>
 implements InstanceCapableSettingsBuilder<MSSQLServer2012SettingsBuilder, MSSQLServer2012DB>{
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<MSSQLServer2012DB> generatesURLForDatabase() {
 		return MSSQLServer2012DB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MSSQLServerSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MSSQLServerSettingsBuilder.java
@@ -39,6 +39,8 @@ import nz.co.gregs.dbvolution.databases.MSSQLServerDB;
 public class MSSQLServerSettingsBuilder extends AbstractMSSQLServerSettingsBuilder<MSSQLServerSettingsBuilder, MSSQLServerDB>
 		implements InstanceCapableSettingsBuilder<MSSQLServerSettingsBuilder, MSSQLServerDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<MSSQLServerDB> generatesURLForDatabase() {
 		return MSSQLServerDB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MariaClusterDBSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MariaClusterDBSettingsBuilder.java
@@ -51,6 +51,7 @@ public class MariaClusterDBSettingsBuilder
 		ClusterCapableSettingsBuilder<MariaClusterDBSettingsBuilder, MariaClusterDB> {
 
 	private final static HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public String getDefaultDriverName() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MariaDBSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MariaDBSettingsBuilder.java
@@ -48,6 +48,7 @@ public class MariaDBSettingsBuilder
 		NamedDatabaseCapableSettingsBuilder<MariaDBSettingsBuilder, MariaDB> {
 
 	private final static HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public String getDefaultDriverName() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MySQLMXJDBSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MySQLMXJDBSettingsBuilder.java
@@ -49,6 +49,7 @@ public class MySQLMXJDBSettingsBuilder extends AbstractMySQLSettingsBuilder<MySQ
 			put("server.initialize-user", "true");
 		}
 	};
+	private static final long serialVersionUID = 1L;
 	
 	@Override
 	public String getDefaultDriverName() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MySQLSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MySQLSettingsBuilder.java
@@ -38,6 +38,8 @@ import nz.co.gregs.dbvolution.databases.MySQLDB;
  */
 public class MySQLSettingsBuilder extends AbstractMySQLSettingsBuilder<MySQLSettingsBuilder, MySQLDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<MySQLDB> generatesURLForDatabase() {
 		return MySQLDB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MySQL_5_7SettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/MySQL_5_7SettingsBuilder.java
@@ -36,6 +36,8 @@ import nz.co.gregs.dbvolution.databases.definitions.MySQLDBDefinition_5_7;
 
 public class MySQL_5_7SettingsBuilder extends AbstractMySQLSettingsBuilder<MySQL_5_7SettingsBuilder, MySQLDB_5_7> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public String getDefaultDriverName() {
 		return MySQLDB_5_7.MYSQLDRIVERNAME;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/NuoDBSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/NuoDBSettingsBuilder.java
@@ -52,6 +52,7 @@ public class NuoDBSettingsBuilder extends AbstractVendorSettingsBuilder<NuoDBSet
 		ClusterCapableSettingsBuilder<NuoDBSettingsBuilder, NuoDB> {
 
 	private final static HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 	private final List<DatabaseConnectionSettings> clusterHost = new ArrayList<>(0);
 
 	@Override

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/Oracle11XESettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/Oracle11XESettingsBuilder.java
@@ -40,6 +40,8 @@ import nz.co.gregs.dbvolution.databases.definitions.Oracle11XEDBDefinition;
  */
 public class Oracle11XESettingsBuilder extends AbstractOracleSettingsBuilder<Oracle11XESettingsBuilder, Oracle11XEDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	public Oracle11XESettingsBuilder() {
 	}
 	@Override

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/Oracle12SettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/Oracle12SettingsBuilder.java
@@ -40,6 +40,8 @@ import nz.co.gregs.dbvolution.databases.definitions.Oracle12DBDefinition;
  */
 public class Oracle12SettingsBuilder extends AbstractOracleSettingsBuilder<Oracle12SettingsBuilder, Oracle12DB> {
 
+	private static final long serialVersionUID = 1L;
+
 	public Oracle12SettingsBuilder() {
 	}
 	

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/OracleAWS11SettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/OracleAWS11SettingsBuilder.java
@@ -39,6 +39,8 @@ import nz.co.gregs.dbvolution.databases.definitions.OracleAWS11DBDefinition;
  * @author gregorygraham
  */
 public class OracleAWS11SettingsBuilder extends AbstractOracleSettingsBuilder<OracleAWS11SettingsBuilder, OracleAWS11DB> {
+
+	private static final long serialVersionUID = 1L;
 	
 	public OracleAWS11SettingsBuilder() {
 	}

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/PostgresOverSSLSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/PostgresOverSSLSettingsBuilder.java
@@ -46,6 +46,7 @@ public class PostgresOverSSLSettingsBuilder extends AbstractPostgresSettingsBuil
 			put("sslfactory", "org.postgresql.ssl.NonValidatingFactory");
 		}
 	};
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public Map<String, String> getDefaultConfigurationExtras() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/PostgresSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/PostgresSettingsBuilder.java
@@ -38,6 +38,8 @@ import nz.co.gregs.dbvolution.databases.PostgresDB;
  */
 public class PostgresSettingsBuilder extends AbstractPostgresSettingsBuilder<PostgresSettingsBuilder, PostgresDB> {
 
+	private static final long serialVersionUID = 1L;
+
 	@Override
 	public Class<PostgresDB> generatesURLForDatabase() {
 		return PostgresDB.class;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/SQLiteSettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/SQLiteSettingsBuilder.java
@@ -46,6 +46,7 @@ public class SQLiteSettingsBuilder extends AbstractVendorSettingsBuilder<SQLiteS
 		UniqueDatabaseCapableSettingsBuilder<SQLiteSettingsBuilder, SQLiteDB> {
 
 	private final static HashMap<String, String> DEFAULT_EXTRAS_MAP = new HashMap<>();
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public String getDefaultDriverName() {


### PR DESCRIPTION
Still haven't done the schema generation but I have fixed the problem with occasionally generating code for the wrong database during a cluster. In this case it was DBMigration holding a reference (correctly) to the cluster and then providing code from the cluster to DBMigrationAction which has the correct database