### PR TITLE
Fixes errors when using H2 Memory DB due to not retaining a persistent connection correctly

### DIFF
--- a/src/main/java/nz/co/gregs/dbvolution/databases/DBDatabaseImplementation.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/DBDatabaseImplementation.java
@@ -981,7 +981,9 @@ public abstract class DBDatabaseImplementation implements DBDatabase, Serializab
 			transactionConnection.commit();
 		} finally {
 			isInATransaction = false;
-			transactionStatement.transactionFinished();
+      if(transactionStatement!=null){
+        transactionStatement.transactionFinished();
+      }
 			discardConnection(transactionConnection);
 			transactionConnection = null;
 			transactionStatement = null;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/DBDatabaseImplementation.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/DBDatabaseImplementation.java
@@ -410,6 +410,7 @@ public abstract class DBDatabaseImplementation implements DBDatabase, Serializab
 					Logger.getLogger(DBDatabase.class.getName()).log(Level.FINEST, null, ex);
 				}
 				if (connectionUsedForPersistentConnection(conn)) {
+          usedConnection(conn);
 					conn = null;
 				}
 			}
@@ -503,6 +504,7 @@ public abstract class DBDatabaseImplementation implements DBDatabase, Serializab
 			if (storedConnection == null) {
 				this.storedConnection = connection;
 				this.storedConnection.createDBStatement();
+        usedConnection(connection);
 			}
 			if (storedConnection.equals(connection)) {
 				return true;

--- a/src/main/java/nz/co/gregs/dbvolution/databases/H2MemoryDB.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/H2MemoryDB.java
@@ -16,9 +16,8 @@
 package nz.co.gregs.dbvolution.databases;
 
 import java.sql.SQLException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.sql.DataSource;
+import nz.co.gregs.dbvolution.databases.connections.DBConnection;
 import nz.co.gregs.dbvolution.databases.settingsbuilders.H2MemorySettingsBuilder;
 import nz.co.gregs.dbvolution.exceptions.UnableToCreateDatabaseConnectionException;
 import nz.co.gregs.dbvolution.exceptions.UnableToFindJDBCDriver;
@@ -57,7 +56,6 @@ public class H2MemoryDB extends H2DB {
 	 */
 	public H2MemoryDB(H2MemorySettingsBuilder dataSource) throws SQLException {
 		super(dataSource);
-		jamDatabaseConnectionOpen();
 	}
 
 	/**
@@ -91,7 +89,6 @@ public class H2MemoryDB extends H2DB {
 	 */
 	public H2MemoryDB(DataSource dataSource) throws SQLException {
 		super(dataSource);
-		jamDatabaseConnectionOpen();
 	}
 
 	/**
@@ -188,15 +185,11 @@ public class H2MemoryDB extends H2DB {
 	public H2MemoryDB clone() throws CloneNotSupportedException {
 		return (H2MemoryDB) super.clone();
 	}
-
-	private void jamDatabaseConnectionOpen() {
-		try {
-			this.storedConnection = getConnection();
-			this.storedConnection.createDBStatement();
-		} catch (UnableToCreateDatabaseConnectionException | UnableToFindJDBCDriver | SQLException ex) {
-			Logger.getLogger(H2DB.class.getName()).log(Level.SEVERE, null, ex);
-		}
-	}
+  
+  @Override
+  final public DBConnection getConnection() throws UnableToCreateDatabaseConnectionException, UnableToFindJDBCDriver, SQLException{
+    return super.getConnection();
+  }
 
 	@Override
 	public H2MemorySettingsBuilder getURLInterpreter() {

--- a/src/main/java/nz/co/gregs/dbvolution/databases/definitions/H2MemoryDBDefinition.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/definitions/H2MemoryDBDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Gregory Graham.
+ *
+ * Commercial licenses are available, please contact info@gregs.co.nz for details.
+ * 
+ * This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. 
+ * To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/4.0/ 
+ * or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ * 
+ * You are free to:
+ *     Share - copy and redistribute the material in any medium or format
+ *     Adapt - remix, transform, and build upon the material
+ * 
+ *     The licensor cannot revoke these freedoms as long as you follow the license terms.               
+ *     Under the following terms:
+ *                 
+ *         Attribution - 
+ *             You must give appropriate credit, provide a link to the license, and indicate if changes were made. 
+ *             You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+ *         NonCommercial - 
+ *             You may not use the material for commercial purposes.
+ *         ShareAlike - 
+ *             If you remix, transform, or build upon the material, 
+ *             you must distribute your contributions under the same license as the original.
+ *         No additional restrictions - 
+ *             You may not apply legal terms or technological measures that legally restrict others from doing anything the 
+ *             license permits.
+ * 
+ * Check the Creative Commons website for any details, legalese, and updates.
+ */
+package nz.co.gregs.dbvolution.databases.definitions;
+
+
+public class H2MemoryDBDefinition extends H2DBDefinition {
+
+  private static final long serialVersionUID = 1L;
+  
+
+	@Override
+	public boolean persistentConnectionRequired() {
+		return true;
+	}
+
+  
+  
+}

--- a/src/main/java/nz/co/gregs/dbvolution/databases/definitions/PostgresDBDefinition.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/definitions/PostgresDBDefinition.java
@@ -61,6 +61,7 @@ public class PostgresDBDefinition extends DBDefinition {
 		return "DROP DATABASE IF EXISTS '" + databaseName + "';";
 	}
 
+  /* TODO Implement CREATE DATABASE for all databases */
 	@Override
 	public String getCreateDatabase(String databaseName) throws UnsupportedOperationException {
 		return "CREATE DATABASE '" + databaseName + "';";

--- a/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2MemorySettingsBuilder.java
+++ b/src/main/java/nz/co/gregs/dbvolution/databases/settingsbuilders/H2MemorySettingsBuilder.java
@@ -34,7 +34,7 @@ import java.sql.SQLException;
 import nz.co.gregs.dbvolution.databases.DatabaseConnectionSettings;
 import nz.co.gregs.dbvolution.databases.H2MemoryDB;
 import nz.co.gregs.dbvolution.databases.definitions.DBDefinition;
-import nz.co.gregs.dbvolution.databases.definitions.H2DBDefinition;
+import nz.co.gregs.dbvolution.databases.definitions.H2MemoryDBDefinition;
 import nz.co.gregs.dbvolution.utility.StringCheck;
 
 public class H2MemorySettingsBuilder
@@ -51,7 +51,7 @@ public class H2MemorySettingsBuilder
 
 	@Override
 	public DBDefinition getDefaultDefinition() {
-		return new H2DBDefinition();
+		return new H2MemoryDBDefinition();
 	}
 
 	@Override

--- a/src/test/java/nz/co/gregs/dbvolution/transactions/DBTableTransactionTest.java
+++ b/src/test/java/nz/co/gregs/dbvolution/transactions/DBTableTransactionTest.java
@@ -29,10 +29,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
- *
- * <p style="color: #F90;">Support DBvolution at
- * <a href="http://patreon.com/dbvolution" target=new>Patreon</a></p>
- *
  * @author Gregory Graham
  */
 public class DBTableTransactionTest extends AbstractTest {


### PR DESCRIPTION
Errors during transaction and scripting tests have been corrected by moving H2 memory databases to a separate DBDefinition and using the proper persistent connection method.
Separately an infinitely loop in the proper persistent connection loop method has been corrected 